### PR TITLE
feat(api): add email field to getTrips requests

### DIFF
--- a/apps/api/src/db/trips.ts
+++ b/apps/api/src/db/trips.ts
@@ -1,7 +1,8 @@
-import { and, eq } from "drizzle-orm"
+import { and, eq, getTableColumns } from "drizzle-orm"
 import { z } from "zod"
 
 import drizzle from "@karr/db"
+import { accountsTable } from "@karr/db/schemas/accounts.js"
 import {
     NewTripSchema,
     TripSchema,
@@ -12,7 +13,13 @@ import {
 import logger from "@karr/util/logger"
 
 export async function getTrips(): Promise<Trip[]> {
-    const trips = await drizzle.select().from(tripsTable)
+    const trips = await drizzle
+        .select({
+            ...getTableColumns(tripsTable),
+            email: accountsTable.email
+        })
+        .from(tripsTable)
+        .leftJoin(accountsTable, eq(tripsTable.account, accountsTable.id))
     return TripSchema.array().parse(trips)
 }
 

--- a/apps/api/src/routes/trips.ts
+++ b/apps/api/src/routes/trips.ts
@@ -133,10 +133,10 @@ function getSlowerData(): Promise<Trip[]> {
                     to: "Acigne",
                     departure: "2025-01-23",
                     price: 5,
-                    createdAt: undefined,
-                    updatedAt: undefined,
-                    account: "715d3ca1-50ec-4bd1-8934-15bd0676a23b",
-                    email: "test@email.com"
+                    email: "john.doe@example.com",
+                    createdAt: new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                    account: "715d3ca1-50ec-4bd1-8934-15bd0676a23b"
                 }
             ])
         }, 3000) // Simulate delay

--- a/apps/api/src/routes/trips.ts
+++ b/apps/api/src/routes/trips.ts
@@ -135,7 +135,8 @@ function getSlowerData(): Promise<Trip[]> {
                     price: 5,
                     createdAt: undefined,
                     updatedAt: undefined,
-                    account: "715d3ca1-50ec-4bd1-8934-15bd0676a23b"
+                    account: "715d3ca1-50ec-4bd1-8934-15bd0676a23b",
+                    email: "test@email.com"
                 }
             ])
         }, 3000) // Simulate delay

--- a/apps/web/src/app/trips/new/newTripForm.tsx
+++ b/apps/web/src/app/trips/new/newTripForm.tsx
@@ -32,7 +32,6 @@ export default function NewTripForm() {
     const form = useForm<NewTripInput>({
         resolver: zodResolver(NewTripInputSchema),
         defaultValues: {
-            account: undefined,
             departure: new Date(Date.now()),
             from: "",
             to: "",

--- a/packages/db/src/schemas/trips.ts
+++ b/packages/db/src/schemas/trips.ts
@@ -12,8 +12,8 @@ export const tripsTable = pgTable("Trips", {
     createdAt: date().defaultNow(),
     updatedAt: date().defaultNow(),
     account: uuid()
-        // .notNull()
         .references(() => accountsTable.id)
+        .notNull()
 })
 
 export const TripSchema = z.object({
@@ -24,8 +24,8 @@ export const TripSchema = z.object({
     price: z.number().min(0),
     createdAt: z.string().optional().nullable(),
     updatedAt: z.string().optional().nullable(),
-    account: z.any().optional(),
-    email: z.string().email()
+    account: z.string().uuid(),
+    email: z.string().email().nullable()
 })
 
 export type Trip = z.infer<typeof TripSchema>
@@ -35,7 +35,7 @@ export const NewTripSchema = z.object({
     to: z.string(),
     departure: z.string(),
     price: z.number().min(0),
-    account: z.any().optional()
+    account: z.string().uuid()
 })
 
 export type NewTrip = z.infer<typeof NewTripSchema>

--- a/packages/db/src/schemas/trips.ts
+++ b/packages/db/src/schemas/trips.ts
@@ -24,7 +24,8 @@ export const TripSchema = z.object({
     price: z.number().min(0),
     createdAt: z.string().optional().nullable(),
     updatedAt: z.string().optional().nullable(),
-    account: z.any().optional()
+    account: z.any().optional(),
+    email: z.string().email()
 })
 
 export type Trip = z.infer<typeof TripSchema>
@@ -43,8 +44,7 @@ export const NewTripInputSchema = z.object({
     from: z.string().min(1),
     to: z.string().min(1),
     departure: z.date(),
-    price: z.number().min(0),
-    account: z.any().optional()
+    price: z.number().min(0)
 })
 
 export type NewTripInput = z.infer<typeof NewTripInputSchema>


### PR DESCRIPTION
# API Updates
- Enhance getTrips function to include the account email. (602f26f)
- Add the email field to the trip data in getSlowerData function. (c60f544)
- Update getSlowerData function to set createdAt, updatedAt, and email fields correctly. (7c22bf6)

# Schema Modifications
- Add the email field to TripSchema and remove the account field from the NewTripInputSchema. (c71501f)
- Enforce the account field as required and update the email field default values. (ede404a)

# Form Adjustments
- Remove the account field from default values in NewTripForm. (7750411)